### PR TITLE
manage ansible with pip and not yum

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+exclude = .git,venv
+max-line-length = 120

--- a/README.md
+++ b/README.md
@@ -1,23 +1,27 @@
 Role Name
 =========
 
-Minimal Ansible role to manage Ansible (and Jinja) with Pip on CentOS 7.3.
+Minimal Ansible role to manage Ansible (and Jinja) with Pip on CentOS 7.3. This includes:
+
+  * redis, the datastore, from yum installed, enabled, and started
+  * redis, the python library, from pip
+  * boto, the python library, for AWS (Route53) plays
 
 Requirements
 ------------
 
  * CentOS 7.x
  * Ansible 2.x
+ * systemd
 
 Role Variables
 --------------
-Name of ansible package in pip
+Pip packages (and version numbers) to provide all the ansible functionality we need
 
-    ansible_pip_ansible_package_name: ansible
-
-Version of ansible package to install from pip
-
-    ansible_pip_ansible_package_version: 2.2.1.0
+ansible_pip_ansible_packages:
+  - ansible==2.2.1.0
+  - boto==2.46.1
+  - redis==2.10.5
 
 Version of pip package to install from yum
 
@@ -27,6 +31,7 @@ Pip package (and supporting packages) to install from yum
 
     ansible_yum_pip_packages:
       - "python2-pip-{{ ansible_yum_pip_package_version }}"
+      - redis-2.8.19  # For fact caching
       - gcc-4.8.5  # Needed for 'pip install cryptography'
       - python-devel-2.7.5  # Needed for 'pip install cryptography'
       - openssl-devel-1.0.1e-60.el7_3.1  # Needed for 'pip install cryptography'

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Pip package (and supporting packages) to install from yum
 
     ansible_yum_pip_packages:
       - "python2-pip-{{ ansible_yum_pip_package_version }}"
-      - redis-2.8.19  # For fact caching
+      - redis-3.2.3  # For fact caching
       - gcc-4.8.5  # Needed for 'pip install cryptography'
       - python-devel-2.7.5  # Needed for 'pip install cryptography'
       - openssl-devel-1.0.1e-60.el7_3.1  # Needed for 'pip install cryptography'

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Tests
 
 Use [molecule](https://github.com/metacloud/molecule) to test this role.
 
+Because this role depends on systemd and might one day need SELinux (as related role ansible-influxdb does), only a Vagrant provider is configured at the moment.
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Pip packages (and version numbers) to provide all the ansible functionality we n
 ansible_pip_ansible_packages:
   - ansible==2.2.1.0
   - boto==2.46.1
+  - dnspython==1.15.0  # For ansible "lookup('dig', ...)"
   - redis==2.10.5
 
 Version of pip package to install from yum

--- a/README.md
+++ b/README.md
@@ -12,9 +12,28 @@ Requirements
 Role Variables
 --------------
 
+Name of ansible package in pip
+
+    ansible_pip_ansible_package_name: ansible
+
+Version of ansible package to install from pip
+
+    ansible_pip_ansible_package_version: 2.2.1.0
+
+Version of pip package to install from yum
+
+    ansible_yum_pip_package_version: 8.1.2
+
+Pip package (and supporting packages) to install from yum
+
+    ansible_yum_pip_packages:
+      - "python2-pip-{{ ansible_yum_pip_package_version }}"
+      - gcc-4.8.5  # Needed for 'pip install cryptography'
+      - python-devel-2.7.5  # Needed for 'pip install cryptography'
+      - openssl-devel-1.0.1e-60.el7_3.1  # Needed for 'pip install cryptography'
+
 Example Playbook
 ----------------
-
 
     - hosts: servers
       roles:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Requirements
 
 Role Variables
 --------------
-
 Name of ansible package in pip
 
     ansible_pip_ansible_package_name: ansible

--- a/README.md
+++ b/README.md
@@ -18,20 +18,16 @@ Role Variables
 --------------
 Pip packages (and version numbers) to provide all the ansible functionality we need
 
-ansible_pip_ansible_packages:
+ansible_pip_packages:
   - ansible==2.2.1.0
   - boto==2.46.1
   - dnspython==1.15.0  # For ansible "lookup('dig', ...)"
   - redis==2.10.5
 
-Version of pip package to install from yum
-
-    ansible_yum_pip_package_version: 8.1.2
-
 Pip package (and supporting packages) to install from yum
 
-    ansible_yum_pip_packages:
-      - "python2-pip-{{ ansible_yum_pip_package_version }}"
+    ansible_rpm_packages:
+      - python2-pip-8.1.2
       - redis-3.2.3  # For fact caching
       - gcc-4.8.5  # Needed for 'pip install cryptography'
       - python-devel-2.7.5  # Needed for 'pip install cryptography'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,13 +1,12 @@
 ---
-ansible_pip_ansible_packages:
+ansible_pip_packages:
   - ansible==2.2.1.0
   - boto==2.46.1
   - dnspython==1.15.0  # For ansible "lookup('dig', ...)"
   - redis==2.10.5
 
-ansible_yum_pip_package_version: 8.1.2
-ansible_yum_pip_packages:
-  - "python2-pip-{{ ansible_yum_pip_package_version }}"
+ansible_rpm_packages:
+  - python2-pip-8.1.2
   - redis-3.2.3  # For fact caching
   - gcc-4.8.5  # Needed for 'pip install cryptography'
   - python-devel-2.7.5  # Needed for 'pip install cryptography'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ ansible_pip_ansible_packages:
 ansible_yum_pip_package_version: 8.1.2
 ansible_yum_pip_packages:
   - "python2-pip-{{ ansible_yum_pip_package_version }}"
-  - redis-2.8.19  # For fact caching
+  - redis-3.2.3  # For fact caching
   - gcc-4.8.5  # Needed for 'pip install cryptography'
   - python-devel-2.7.5  # Needed for 'pip install cryptography'
   - openssl-devel-1.0.1e-60.el7_3.1  # Needed for 'pip install cryptography'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,10 @@
 ---
-ansible_pip_package_version: 8.1.2
-ansible_pip_packages:
-  - "python2-pip-{{ ansible_pip_package_version }}"
+ansible_pip_ansible_package_name: ansible
+ansible_pip_ansible_package_version: 2.2.1.0
+
+ansible_yum_pip_package_version: 8.1.2
+ansible_yum_pip_packages:
+  - "python2-pip-{{ ansible_yum_pip_package_version }}"
+  - gcc-4.8.5  # Needed for 'pip install cryptography'
+  - python-devel-2.7.5  # Needed for 'pip install cryptography'
+  - openssl-devel-1.0.1e-60.el7_3.1  # Needed for 'pip install cryptography'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
-# defaults file for ansible-ansible
+ansible_pip_package_version: 8.1.2
+ansible_pip_packages:
+  - "python2-pip-{{ ansible_pip_package_version }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 ansible_pip_ansible_packages:
   - ansible==2.2.1.0
+  - boto==2.46.1
   - redis==2.10.5
 
 ansible_yum_pip_package_version: 8.1.2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 ansible_pip_ansible_packages:
   - ansible==2.2.1.0
   - boto==2.46.1
+  - dnspython==1.15.0  # For ansible "lookup('dig', ...)"
   - redis==2.10.5
 
 ansible_yum_pip_package_version: 8.1.2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,12 @@
 ---
-ansible_pip_ansible_package_name: ansible
-ansible_pip_ansible_package_version: 2.2.1.0
+ansible_pip_ansible_packages:
+  - ansible==2.2.1.0
+  - redis==2.10.5
 
 ansible_yum_pip_package_version: 8.1.2
 ansible_yum_pip_packages:
   - "python2-pip-{{ ansible_yum_pip_package_version }}"
+  - redis-2.8.19  # For fact caching
   - gcc-4.8.5  # Needed for 'pip install cryptography'
   - python-devel-2.7.5  # Needed for 'pip install cryptography'
   - openssl-devel-1.0.1e-60.el7_3.1  # Needed for 'pip install cryptography'

--- a/molecule.yml
+++ b/molecule.yml
@@ -2,12 +2,19 @@
 dependency:
   name: galaxy
 driver:
-  name: docker
-docker:
-  containers:
+  name: vagrant
+vagrant:
+  platforms:
+    - name: centos/7
+      box: centos/7
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 256
+        cpus: 1
+  instances:
     - name: ansible-ansible
-      image: centos
-      image_version: centos7.3.1611
       ansible_groups:
         - group1
 verifier:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-docker-py
 flake8
 molecule
+python-vagrant

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,0 +1,7 @@
+---
+- name: Enable and (re)start redis service
+  service:
+    name: redis
+    enabled: yes
+    state: started
+    use: systemd

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,7 +6,7 @@
   tags:
     - skip_ansible_lint
 
-- name: Uninstall Yum Ansible packages
+- name: Uninstall Ansible packages with Yum
   package:
     name: "{{ item }}"
     state: absent
@@ -14,14 +14,15 @@
     - "ansible"
     - "python-jinja2"
 
-- name: Install Pip package from Yum
+- name: Install Pip packages from Yum
   package:
     name: "{{ item }}"
     state: present
   with_items:
     - "{{ ansible_yum_pip_packages }}"
 
-- name: Install Ansible package from Pip
+- name: Install Ansible packages from Pip
   pip:
-    name: "{{ ansible_pip_ansible_package_name }}"
-    version: "{{ ansible_pip_ansible_package_version }}"
+    name: "{{ item }}"
+  with_items:
+    - "{{ ansible_pip_ansible_packages }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,28 @@
+---
+- name: Add EPEL repository
+  yum_repository:
+    name: epel
+    description: EPEL YUM repo
+    baseurl: https://mirror.csclub.uwaterloo.ca/fedora/epel/$releasever/$basearch/
+    gpgcheck: yes
+    gpgkey: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+
+- name: Import RPM key
+  rpm_key:
+    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+    state: present
+
+- name: Uninstall Yum Ansible packages
+  package:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - "ansible"
+    - "python-jinja2"
+
+- name: Install Yum Pip package
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "{{ ansible_pip_packages }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,16 +1,10 @@
 ---
 - name: Add EPEL repository
-  yum_repository:
-    name: epel
-    description: EPEL YUM repo
-    baseurl: https://mirror.csclub.uwaterloo.ca/fedora/epel/$releasever/$basearch/
-    gpgcheck: yes
-    gpgkey: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
-
-- name: Import RPM key
-  rpm_key:
-    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
-    state: present
+  package:
+    name: epel-release
+    state: latest
+  tags:
+    - skip_ansible_lint
 
 - name: Uninstall Yum Ansible packages
   package:
@@ -20,14 +14,14 @@
     - "ansible"
     - "python-jinja2"
 
-- name: Install Yum Pip package
+- name: Install Pip package from Yum
   package:
     name: "{{ item }}"
     state: present
   with_items:
     - "{{ ansible_yum_pip_packages }}"
 
-- name: Install Pip Ansible package
+- name: Install Ansible package from Pip
   pip:
     name: "{{ ansible_pip_ansible_package_name }}"
     version: "{{ ansible_pip_ansible_package_version }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -25,4 +25,9 @@
     name: "{{ item }}"
     state: present
   with_items:
-    - "{{ ansible_pip_packages }}"
+    - "{{ ansible_yum_pip_packages }}"
+
+- name: Install Pip Ansible package
+  pip:
+    name: "{{ ansible_pip_ansible_package_name }}"
+    version: "{{ ansible_pip_ansible_package_version }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,10 +19,10 @@
     name: "{{ item }}"
     state: present
   with_items:
-    - "{{ ansible_yum_pip_packages }}"
+    - "{{ ansible_rpm_packages }}"
 
 - name: Install Ansible packages from Pip
   pip:
     name: "{{ item }}"
   with_items:
-    - "{{ ansible_pip_ansible_packages }}"
+    - "{{ ansible_pip_packages }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,3 @@
 ---
 - { include: install.yml, tags: ["install"] }
+- { include: configure.yml, tags: ["configure"] }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-# tasks file for ansible-ansible
+- { include: install.yml, tags: ["install"] }

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -16,3 +16,8 @@ def test_yum_packages_not_installed(Package):
 def test_pip_installed(Package):
     pip_pkg = Package("python2-pip")
     assert pip_pkg.is_installed
+
+
+def test_pip_list_shows_jinja(Command):
+    cmd = Command("pip list")
+    assert "Jinja2" in cmd.stdout

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -18,9 +18,9 @@ def test_pip_installed(Package):
     assert pip_pkg.is_installed
 
 
-def test_pip_list_shows_jinja(Command):
-    cmd = Command("pip list")
-    assert "Jinja2" in cmd.stdout
+def test_pip_list_shows_jinja(PipPackage):
+    packages = PipPackage.get_packages()
+    assert "Jinja2" in packages.keys()
 
 
 def test_ansible_service_enabled(Service):

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,12 +1,18 @@
 import testinfra.utils.ansible_runner
 
+
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     '.molecule/ansible_inventory').get_hosts('all')
 
 
-def test_hosts_file(File):
-    f = File('/etc/hosts')
+def test_yum_packages_not_installed(Package):
+    ansible_pkg = Package("ansible")
+    assert not ansible_pkg.is_installed
 
-    assert f.exists
-    assert f.user == 'root'
-    assert f.group == 'root'
+    jinja_pkg = Package("python-jinja2")
+    assert not jinja_pkg.is_installed
+
+
+def test_pip_installed(Package):
+    pip_pkg = Package("python2-pip")
+    assert pip_pkg.is_installed

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -33,3 +33,13 @@ def test_ansible_with_redis_caching_runs(Command):
     assert write_ansible_cfg.rc == 0
     run_ansible = Command("ANSIBLE_CONFIG=/tmp/ansible_with_fact_caching.cfg ansible localhost -a 'true'")
     assert run_ansible.rc == 0
+
+
+def test_ansible_with_route53_runs(Command):
+    cmd = Command("ansible localhost -m route53 -a 'zone=example.com command=get type=A record='")
+    assert "boto required for this module" not in cmd.stdout
+    # I don't want to bother with a one-off set of powerless credentials for
+    # this test. I also don't want to really talk to AWS every time this test
+    # runs. If we get as far as importing boto and trying to authenticate,
+    # that's pretty good for an integration test.
+    assert "boto.exception.NoAuthHandlerFound" in cmd.stdout

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -21,3 +21,15 @@ def test_pip_installed(Package):
 def test_pip_list_shows_jinja(Command):
     cmd = Command("pip list")
     assert "Jinja2" in cmd.stdout
+
+
+def test_ansible_service_enabled(Service):
+    svc = Service("redis")
+    assert svc.is_enabled
+
+
+def test_ansible_with_redis_caching_runs(Command):
+    write_ansible_cfg = Command("echo -e '[defaults]\nfact_caching = redis' > /tmp/ansible_with_fact_caching.cfg")
+    assert write_ansible_cfg.rc == 0
+    run_ansible = Command("ANSIBLE_CONFIG=/tmp/ansible_with_fact_caching.cfg ansible localhost -a 'true'")
+    assert run_ansible.rc == 0


### PR DESCRIPTION
I need this because I need a Jinja2 modern enough to handle this situation:
https://github.com/idi-ops/ansible-grafana/pull/1/commits/83171738d0ba1f45d1a1e037a2402f821d1dd21c

I have already run this against i40. Predictably, it didn't work when I ran it *from* i40 (``ImportError: No module named filter``). It did work when I ran it from my local machine against i40. Yay!